### PR TITLE
No index nordugrid  -  changes to default /etc/arc/client.conf

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,15 @@ arc_deb_client_packages:
 arc_manage_vomses: True
 # If True, overwrite the /etc/arc/client.conf file with a FGI/FGCI sensible default
 arc_client_conf: True
+
+# To define your own settings in /etc/arc/client.conf, put them in the below variable
+# arc_client_conf_settings:
+# [registry/index1]
+# url=ldap://giis1.fgi.csc.fi:2135/Mds-Vo-name=Finland,o=grid
+# registryinterface=org.nordugrid.ldapegiis
+# default=yes
+# [registry/index2]
+# url=ldap://giis2.fgi.csc.fi:2135/Mds-Vo-name=Finland,o=grid
+# registryinterface=org.nordugrid.ldapegiis
+# default=yes
+# 

--- a/files/client.conf
+++ b/files/client.conf
@@ -1,2 +1,0 @@
-[common]
-defaultservices=index:ARC0:ldap://giis1.fgi.csc.fi:2135/Mds-Vo-name=Finland,o=grid index:ARC0:ldap://giis2.fgi.csc.fi:2135/Mds-Vo-name=Finland,o=grid, index:ARC0:ldap://index1.nordugrid.org:2135/Mds-Vo-name=Finland,o=grid index:ARC0:ldap://index2.nordugrid.org:2135/Mds-Vo-name=Finland,o=grid index:ARC0:ldap://index3.nordugrid.org:2135/Mds-Vo-name=Finland,o=grid index:ARC0:ldap://index4.nordugrid.org:2135/Mds-Vo-name=Finland,o=grid

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -28,7 +28,7 @@
     when: repo_egi_trustanchors
     with_items: "{{ repo_egi_deb_packages }}"
 
-  - name: Add ARC client.conf with sensible defaults
-    copy: src=client.conf dest=/etc/arc/client.conf owner=root mode=0644
+  - name: Template ARC client.conf with sensible defaults
+    template: src=client.conf.j2 dest=/etc/arc/client.conf owner=root mode=0644
     when: arc_client_conf
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -41,7 +41,7 @@
         backup=yes
     when: arc_frontend_excludeCAs.stat.exists
 
-  - name: Add ARC client.conf with sensible defaults
-    copy: src=client.conf dest=/etc/arc/client.conf owner=root mode=0644
+  - name: Template ARC client.conf with sensible defaults
+    template: src=client.conf.j2 dest=/etc/arc/client.conf owner=root mode=0644
     when: arc_client_conf
 

--- a/templates/client.conf.j2
+++ b/templates/client.conf.j2
@@ -1,0 +1,15 @@
+# {{ ansible_managed }}
+{% if arc_client_conf_settings is defined %}
+{{ arc_client_conf_settings }}
+{% else %}
+
+[registry/index1]
+url=ldap://giis1.fgi.csc.fi:2135/Mds-Vo-name=Finland,o=grid
+registryinterface=org.nordugrid.ldapegiis
+default=yes
+[registry/index2]
+url=ldap://giis2.fgi.csc.fi:2135/Mds-Vo-name=Finland,o=grid
+registryinterface=org.nordugrid.ldapegiis
+default=yes
+
+{% endif %}

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -119,7 +119,8 @@ function test_playbook(){
 }
 function extra_tests(){
 
-    ${APACHE_CTL} configtest || (echo "php --version was failed" && exit 100 )
+    echo "TEST: cat /etc/arc/client.conf"
+    cat /etc/arc/client.conf
 }
 
 
@@ -134,7 +135,7 @@ function main(){
     test_playbook_syntax
     test_playbook
     test_playbook_check
-#    extra_tests
+    extra_tests
 
 }
 


### PR DESCRIPTION
Based on suggestions in https://bugzilla.nordugrid.org/show_bug.cgi?id=3606

Shall we update the arc.client to this?
The "arcinfo" command is now much faster , 0.2s on io and 20s on carpo