### PR TITLE
prepare for ansible 2.4: include -> include_tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ env:
   - IMAGE_BUILD_PLATFORM=devel-centos7
   - IMAGE_BUILD_PLATFORM=devel-ubuntu1510
 
-install: travis_wait 25
-  - npm install -g validate-dockerfile
+install: travis_wait 25 npm install -g validate-dockerfile
 
 before_script:
   # TESTDIR = Where the stable-centos/Dockerfile is located

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - IMAGE_BUILD_PLATFORM=devel-centos7
   - IMAGE_BUILD_PLATFORM=devel-ubuntu1510
 
-install:
+install: travis_wait 25
   - npm install -g validate-dockerfile
 
 before_script:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
   # - Apache
   # - CC-BY
   license: MIT
-  min_ansible_version: 2.1
+  min_ansible_version: 2.4
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your 
@@ -40,8 +40,9 @@ galaxy_info:
   #  - 19
   #  - 20
   #  - 21
-    - 22
+  #  - 22
     - 23
+    - 24
   #- name: Windows
   #  versions:
   #  - all

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for ansible-role-arc-client
 #
-  - include: redhat.yml
+  - include_tasks: redhat.yml
     when: ansible_os_family == "RedHat"
-  - include: debian.yml
+  - include_tasks: debian.yml
     when: ansible_os_family == "Debian"

--- a/tests/devel-ubuntu1510/Dockerfile
+++ b/tests/devel-ubuntu1510/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.10
+FROM ubuntu:16.04
 # You can change the FROM Instruction to your existing images if you like and build it with same tag
 ENV container docker
 ENV LC_ALL C
@@ -8,10 +8,10 @@ APT::Get::Assume-Yes "true"; \n\
 APT::Get::force-yes "true"; \n\
 APT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01buildconfig
 RUN mkdir -p  /etc/apt/sources.d/
-RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt wily main restricted universe multiverse \n\
-deb mirror://mirrors.ubuntu.com/mirrors.txt wily-updates main restricted universe multiverse \n\
-deb mirror://mirrors.ubuntu.com/mirrors.txt wily-backports main restricted universe multiverse \n\
-deb mirror://mirrors.ubuntu.com/mirrors.txt wily-security main restricted universe multiverse" > /etc/apt/sources.d/ubuntu-mirrors.list
+RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt xenial main restricted universe multiverse \n\
+deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-updates main restricted universe multiverse \n\
+deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-backports main restricted universe multiverse \n\
+deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-security main restricted universe multiverse" > /etc/apt/sources.d/ubuntu-mirrors.list
 RUN apt-get update && apt-get install systemd sudo && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN cd /lib/systemd/system/sysinit.target.wants/; ls | grep -v systemd-tmpfiles-setup | xargs rm -f $1 \
 rm -f /lib/systemd/system/multi-user.target.wants/*;\

--- a/tests/devel-ubuntu1510/Dockerfile
+++ b/tests/devel-ubuntu1510/Dockerfile
@@ -36,7 +36,7 @@ RUN \
   apt-get install -y byobu curl git htop man unzip vim wget python-pip tree && \
   apt-get install -y libyaml-dev python-dev python-jinja2 python-httplib2 python-keyczar python-paramiko && \
   apt-get install -y libffi-dev libssl-dev && \
-  pip install pyrax pysphere boto passlib dnspython
+  pip install setuptools pyrax pysphere boto passlib dnspython
 
 RUN mkdir /etc/ansible/
 RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -70,11 +70,6 @@ rm -Rf ansible
 
 }
 
-function install_ansible_24() {
-
-#yum install --nogpgcheck -y http://idris.fgi.csc.fi/ansible/ansible-2.4.0.0-100.git201709190223.d14467b.HEAD.el7.noarch.rpm
-
-}
 
 function install_os_deps() {
 echo "TEST: installing os deps"

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -70,6 +70,12 @@ rm -Rf ansible
 
 }
 
+function install_ansible_24() {
+
+yum install --nogpgcheck -y http://idris.fgi.csc.fi/ansible/ansible-2.4.0.0-100.git201709190223.d14467b.HEAD.el7.noarch.rpm
+
+}
+
 function install_os_deps() {
 echo "TEST: installing os deps"
 
@@ -128,6 +134,7 @@ set -e
 function main(){
 #    install_os_deps
 #    install_ansible_devel
+    install_ansible_24
     show_version
 #    tree_list
 #    test_install_requirements

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -72,7 +72,7 @@ rm -Rf ansible
 
 function install_ansible_24() {
 
-yum install --nogpgcheck -y http://idris.fgi.csc.fi/ansible/ansible-2.4.0.0-100.git201709190223.d14467b.HEAD.el7.noarch.rpm
+#yum install --nogpgcheck -y http://idris.fgi.csc.fi/ansible/ansible-2.4.0.0-100.git201709190223.d14467b.HEAD.el7.noarch.rpm
 
 }
 
@@ -134,7 +134,7 @@ set -e
 function main(){
 #    install_os_deps
 #    install_ansible_devel
-    install_ansible_24
+#    install_ansible_24
     show_version
 #    tree_list
 #    test_install_requirements


### PR DESCRIPTION
ansible 2.4.0 is coming, and include causes depreciation warnings. Change include to include_tasks.