### PR TITLE
Modernize travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: minimal
+language: generic
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
-language: python
-
-sudo: required
-dist: trusty
-group: edge
+language: minimal
 
 services:
   - docker


### PR DESCRIPTION
- Trusty has been deprecated, use the default (xenial at the moment).

- sudo is always available as the travis container-based
  infrastructure has been deprecated.

- group tag isn't necessary anymore either.

- Set language: minimal which should give a smaller and faster image.